### PR TITLE
DataTypeの更新

### DIFF
--- a/main/logbook/data/DataType.java
+++ b/main/logbook/data/DataType.java
@@ -37,17 +37,19 @@ public enum DataType {
     BATTLE_MIDNIGHT("/kcsapi/api_req_battle_midnight/battle"),
     /** 戦闘(夜戦) */
     BATTLE_SP_MIDNIGHT("/kcsapi/api_req_battle_midnight/sp_midnight"),
-    /** 戦闘(連合艦隊夜戦) */
-    BATTLE_COMBINED_MIDNIGHT_BATTLE("/kcsapi/api_req_combined_battle/midnight_battle"),
     /** 戦闘(夜戦→昼戦) */
     BATTLE_NIGHT_TO_DAY("/kcsapi/api_req_sortie/night_to_day"),
     /** 戦闘(航空戦) */
     BATTLE_AIRBATTLE("/kcsapi/api_req_sortie/airbattle"),
-    /** 戦闘(航空戦) */
-    COMBINED_AIR_BATTLE("/kcsapi/api_req_combined_battle/airbattle"),
-    /** 戦闘 */
+    /** 戦闘(連合艦隊) */
     COMBINED_BATTLE("/kcsapi/api_req_combined_battle/battle"),
-    /** 戦闘 */
+    /** 戦闘(連合艦隊・夜戦) */
+    COMBINED_BATTLE_MIDNIGHT("/kcsapi/api_req_combined_battle/midnight_battle"),
+    /** 戦闘(連合艦隊・夜戦) */
+    COMBINED_BATTLE_SP_MIDNIGHT("/kcsapi/api_req_combined_battle/sp_midnight"),
+    /** 戦闘(連合艦隊・航空戦) */
+    COMBINED_BATTLE_AIRBATTLE("/kcsapi/api_req_combined_battle/airbattle"),
+    /** 戦闘(連合艦隊) */
     COMBINED_BATTLE_WATER("/kcsapi/api_req_combined_battle/battle_water"),
     /** 戦闘結果 */
     BATTLE_RESULT("/kcsapi/api_req_sortie/battleresult"),

--- a/main/logbook/data/context/GlobalContext.java
+++ b/main/logbook/data/context/GlobalContext.java
@@ -351,7 +351,7 @@ public final class GlobalContext {
                 doBattle(data);
                 break;
             // 海戦
-            case COMBINED_AIR_BATTLE:
+            case COMBINED_BATTLE_AIRBATTLE:
                 doBattle(data);
                 break;
             // 海戦


### PR DESCRIPTION
- 連合艦隊戦闘時のDataType名を通常戦闘時の命名規則に添わせました
  - 航空戦マスは AIRBATTLE に統一
  - 連合艦隊時の夜戦を他と同じように COMBINED_ で始まるようにrename
- 連合艦隊夜戦マスのAPIを追加しました（2015春イベE6にある夜戦マス）