### PR TITLE
Hot key for ShipFilterGroupDialog

### DIFF
--- a/main/logbook/gui/ApplicationMain.java
+++ b/main/logbook/gui/ApplicationMain.java
@@ -376,7 +376,8 @@ public final class ApplicationMain {
         new MenuItem(etcmenu, SWT.SEPARATOR);
         // その他-グループエディター
         MenuItem shipgroup = new MenuItem(etcmenu, SWT.NONE);
-        shipgroup.setText("グループエディター(&G)");
+        shipgroup.setText("グループエディター(&G)\tCtrl+G");
+        shipgroup.setAccelerator(SWT.CTRL + 'G');
         shipgroup.addSelectionListener(new SelectionAdapter() {
             @Override
             public void widgetSelected(SelectionEvent e) {


### PR DESCRIPTION
Ship group dialog is useful and frequently functional, assign an convenient hot key for it.

![shipgroup](https://cloud.githubusercontent.com/assets/1611811/7901282/35b00dda-07b2-11e5-9b1c-3dbddef1027c.png)