### PR TITLE
高速修復及び母港に戻る前に修復完了した艦娘の情報更新に対応

### DIFF
--- a/main/logbook/data/DataType.java
+++ b/main/logbook/data/DataType.java
@@ -29,6 +29,8 @@ public enum DataType {
     MATERIAL("/kcsapi/api_get_member/material"),
     /** 入渠ドック */
     NDOCK("/kcsapi/api_get_member/ndock"),
+    /** 高速修復 */
+    SPEED_CHANGE("/kcsapi/api_req_nyukyo/speedchange"),
     /** アイテム一覧 */
     SLOTITEM_MEMBER("/kcsapi/api_get_member/slot_item"),
     /** 艦隊 */
@@ -61,6 +63,8 @@ public enum DataType {
     CREATE_ITEM("/kcsapi/api_req_kousyou/createitem"),
     /** 建造 */
     CREATE_SHIP("/kcsapi/api_req_kousyou/createship"),
+    /** 高速建造 */
+    CRATE_SHIP_SPEED_CHANGE("/kcsapi/api_req_kousyou/createship_speedchange"),
     /** 建造ドック */
     KDOCK("/kcsapi/api_get_member/kdock"),
     /** 建造(入手) */

--- a/main/logbook/dto/ShipDto.java
+++ b/main/logbook/dto/ShipDto.java
@@ -78,7 +78,7 @@ public final class ShipDto extends AbstractDto {
     private final float expraito;
 
     /** HP */
-    private final long nowhp;
+    private long nowhp;
 
     /** MaxHP */
     private final long maxhp;
@@ -370,6 +370,10 @@ public final class ShipDto extends AbstractDto {
      */
     public long getNowhp() {
         return this.nowhp;
+    }
+
+    public void setNowHp(long nowhp) {
+        this.nowhp = nowhp;
     }
 
     /**


### PR DESCRIPTION
入渠で高速修復を行ったとき、または母港に戻る前に入渠情報を表示した場合にすでに修復が完了した艦娘がいた場合、メインのタブの入渠情報の更新および艦娘のHPを最大にセットし、その艦娘が艦隊に編成されていたらその艦隊の情報も更新するようにしてみました。よろしければ取り込みお願いします。