### PR TITLE
艦載機の全滅時など熟練度が０になった場合にクリアされないのを修正

### DIFF
--- a/main/logbook/data/context/GlobalContext.java
+++ b/main/logbook/data/context/GlobalContext.java
@@ -814,6 +814,8 @@ public final class GlobalContext {
                     ItemContext.level().put(id, level);
                     if (alv > 0) {
                         ItemContext.alv().put(id, alv);
+                    } else {
+                        ItemContext.alv().remove(id);
                     }
                 }
             }


### PR DESCRIPTION
艦載機が全滅して熟練度が０に戻った場合でも、所有艦娘のテーブルなどに表示されている熟練度が０に戻らない問題を修正してみました。よろしくお願いします。